### PR TITLE
Catch rate limit errors and raise them so that callers can response appropriately.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ghx (0.2.1)
+    ghx (0.3.0)
       faraday (~> 2.9.0)
       faraday-retry (~> 2.2.1)
       octokit

--- a/lib/ghx.rb
+++ b/lib/ghx.rb
@@ -13,6 +13,7 @@ class Hash
 end
 
 require_relative "version"
+require_relative "ghx/errors"
 require_relative "ghx/graphql_client"
 require_relative "ghx/rest_client"
 require_relative "ghx/dependabot"

--- a/lib/ghx/errors.rb
+++ b/lib/ghx/errors.rb
@@ -1,5 +1,7 @@
 module GHX
   class GHXError < StandardError; end
+
   class RateLimitExceededError < GHXError; end
+
   class OtherApiError < GHXError; end
 end

--- a/lib/ghx/errors.rb
+++ b/lib/ghx/errors.rb
@@ -1,0 +1,5 @@
+module GHX
+  class GHXError < StandardError; end
+  class RateLimitExceededError < GHXError; end
+  class OtherApiError < GHXError; end
+end

--- a/lib/ghx/issue.rb
+++ b/lib/ghx/issue.rb
@@ -13,10 +13,6 @@ module GHX
       data.fetch("items").to_a.map do |issue_data|
         new(owner: owner, repo: repo, **issue_data)
       end
-    rescue => e
-      GHX.logger.error "Error searching for issues with query: #{e.message}"
-      GHX.logger.error "Received data: #{data}"
-      []
     end
 
     # Find an issue by its number

--- a/lib/ghx/rest_client.rb
+++ b/lib/ghx/rest_client.rb
@@ -71,7 +71,7 @@ module GHX
 
       if response.code.to_i < 400
         response
-      elsif response.code.to_i == 403
+      elsif [403, 429].include?(response.code.to_i)
         if response["X-RateLimit-Remaining"].to_i == 0
           reset_time = Time.at(response["X-RateLimit-Reset"].to_i)
           raise GHX::RateLimitExceededError, "GitHub API rate limit exceeded. Try again after #{reset_time}"
@@ -82,6 +82,5 @@ module GHX
         raise GHX::OtherApiError, "GitHub API returned an error: #{response.code} #{response.body}"
       end
     end
-
   end
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module GHX
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
### Description
When a rate limit is hit on the REST client, raise a `RateLimitExceededError`, so that callers can then handle that situation as desired.

### Reason/Reference
If you don't know you hit a rate limit, you might continue errantly.