### PR TITLE
Fix bug in normalized_field_value_name.

### DIFF
--- a/lib/ghx/project_item.rb
+++ b/lib/ghx/project_item.rb
@@ -185,7 +185,7 @@ module GHX
     end
 
     def normalized_field_value_name(name)
-      name.tr(" ", "_").downcase
+      name.tr(" ", "_").tr("-", "_").downcase
     end
 
     # Extracts the value from the field based on the field's data type. Thank you GraphQL for making this totally asinine.

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module GHX
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end


### PR DESCRIPTION
### Description
This updates the `normalized_field_value_name` method to handle field names with hyphens. GH recently added a field with a hyphon ("Sub-issue") that was breaking things.

### Reason/Reference
Bugfix